### PR TITLE
fix: update fulcio url

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ async function run() {
   const cmd = ["run"];
 
   if (enableSigstore) {
-    fulcio = fulcio || "https://v1.fulcio.sigstore.dev";
+    fulcio = fulcio || "https://fulcio.sigstore.dev";
     fulcioOidcClientId =
       fulcioOidcClientId || "https://oauth2.sigstore.dev/auth";
     fulcioOidcIssuer = fulcioOidcIssuer || "sigstore";


### PR DESCRIPTION
v1.fulcio.sigstore.dev is no longer reachable. fulcio.sigstore.dev seems to be the new url. I've tested this locally with witness and it works.