### PR TITLE
feat: choose where to install witness

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,9 +83,10 @@ host your own instances.
 
 | Name                     | Description                                                                                          | Required | Default                               |
 | ------------------------ | ---------------------------------------------------------------------------------------------------- | -------- | ------------------------------------- |
-| enable-sigstore             | Use Sigstore for attestation. Sets default values for fulcio, fulcio-oidc-client-id, fulcio-oidc-issuer, and timestamp-servers when true | No       | true |
+| witness-install-dir      | Directory to install the witness tool into. The directory will attempted to be created if it does not exists | No       | ./ |
+| enable-sigstore          | Use Sigstore for attestation. Sets default values for fulcio, fulcio-oidc-client-id, fulcio-oidc-issuer, and timestamp-servers when true | No       | true |
 | enable-archivista        | Use Archivista to store or retrieve attestations                                                     | No       | true                                 | true |
-| archivista-server        | URL of the Archivista server to store or retrieve attestations                                      | No       | <https://archivista.testifysec.io>      |
+| archivista-server        | URL of the Archivista server to store or retrieve attestations                                       | No       | <https://archivista.testifysec.io>      |
 | attestations             | Attestations to record, space-separated                                                              | No       | environment git github                      |
 | certificate              | Path to the signing key's certificate                                                                | No       |                                       |
 | fulcio                   | Fulcio address to sign with                                                                          | No       |                                       |

--- a/index.js
+++ b/index.js
@@ -9,9 +9,9 @@ const path = require("path");
 const tc = require('@actions/tool-cache');
 
 async function run() {
+  const witnessInstallDir = core.getInput('witness-install-dir') || './';
   // Download Witness
   const version = core.getInput("version");
-  const witnessExtractPath = './'
 
   let witnessPath = tc.find('witness', version);
   console.log('Cached Witness Path: ' + witnessPath);
@@ -30,7 +30,11 @@ async function run() {
      witnessTar = await tc.downloadTool('https://github.com/in-toto/witness/releases/download/v' + version + '/witness_' + version + '_linux_amd64.tar.gz');
     }
 
-    witnessPath = await tc.extractTar(witnessTar, witnessExtractPath);
+    if (!fs.existsSync(witnessInstallDir)) {
+      fs.mkdirSync(witnessInstallDir, { recursive: true });
+    }
+
+    witnessPath = await tc.extractTar(witnessTar, witnessInstallDir);
     const cachedPath = await tc.cacheFile(witnessPath + 'witness', 'witness', 'witness', version);
     console.log('Witness cached at: ' + cachedPath);
   }


### PR DESCRIPTION
Currently witness installs to the current directory the action is running in. This can cause dirty git trees, and tools that expect a clean git tree may hate this. This allows users of the witness-run-action the ability to choose where to install witness.