### PR TITLE
fix: replace hardcoded headers with secret-based auth for witness wokflow

### DIFF
--- a/.github/workflows/witness.yml
+++ b/.github/workflows/witness.yml
@@ -51,13 +51,12 @@ on:
         default: "https://archivista.testifysec.io"
         required: false
         type: string
-      archivista-headers:
-        default: ""
-        required: false
-        type: string
       workingdir:
         required: false
         type: string
+    secrets:
+      archivista-headers-token:
+        required: false
 
 jobs:
   witness:
@@ -75,11 +74,11 @@ jobs:
           path: /tmp
 
       - if: ${{ inputs.pre-command != '' && inputs.pull_request == false }}
-        uses: testifysec/witness-run-action@d013777c8bc3ac5ce480c003f0f9db0206629bd3
+        uses: testifysec/witness-run-action@main
         with:
           version: ${{ inputs.version }}
           archivista-server: ${{ inputs.archivista-server }}
-          archivista-headers: ${{ inputs.archivista-headers }}
+          archivista-headers: "Authorization: Token ${{ secrets.archivista-headers-token }}"
           workingdir: ${{ inputs.workingdir }}
           step: pre-${{ inputs.step }}
           attestations: ${{ inputs.pre-command-attestations }}
@@ -89,11 +88,11 @@ jobs:
         working-directory: ${{ inputs.workingdir }}
 
       - if: ${{ inputs.pull_request == false }}
-        uses: testifysec/witness-run-action@d013777c8bc3ac5ce480c003f0f9db0206629bd3
+        uses: testifysec/witness-run-action@main
         with:
           version: ${{ inputs.version }}
           archivista-server: ${{ inputs.archivista-server }}
-          archivista-headers: ${{ inputs.archivista-headers }}
+          archivista-headers: "Authorization: Token ${{ secrets.archivista-headers-token }}"
           workingdir: ${{ inputs.workingdir }}
           step: ${{ inputs.step }}
           attestations: ${{ inputs.attestations }}

--- a/README.md
+++ b/README.md
@@ -36,6 +36,34 @@ jobs:
           command: make build
 ```
 
+## Using Reusable Workflows
+
+For a streamlined setup, you can use our reusable workflow. This is especially useful when you need to pass secrets like API tokens for authentication:
+
+```yaml
+permissions:
+  id-token: write # This is required for requesting the JWT
+  contents: read  # This is required for actions/checkout
+
+name: Build with Witness
+on: [push, pull_request]
+
+jobs:
+  build:
+    uses: testifysec/witness-run-action/.github/workflows/witness.yml@main
+    with:
+      pull_request: ${{ github.event_name == 'pull_request' }}
+      step: build
+      attestations: "git github environment"
+      archivista-server: "https://archivista.yourdomain.com"
+      command: |
+        make build
+    secrets:
+      archivista-headers-token: ${{ secrets.WITNESS_API_TOKEN }}
+```
+
+> **Important:** When using reusable workflows, secrets must be passed using the `secrets` keyword, not the `with` keyword. This ensures proper security handling of sensitive values like API tokens. Pass your API token as `archivista-headers-token` and the workflow will format it correctly as an authorization header.
+
 ## Using Sigstore and Archivista Flags
 
 This action supports the use of Sigstore and Archivista for creating attestations.


### PR DESCRIPTION
Removes the archivista-headers input parameter and replaces it with a secure archivista-headers-token secret that gets formatted as an authorization header. Updates witness-run-action to use main branch instead of pinned commit.

- Enhances security by moving sensitive tokens from inputs to secrets
- Adds comprehensive documentation for reusable workflow usage
- Explains proper secret handling patterns for GitHub Actions