### PR TITLE
fix: sets default timestamp server if none provided rather than always using freetsa

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -30207,7 +30207,7 @@ async function run() {
     fulcio = fulcio || "https://fulcio.sigstore.dev";
     fulcioOidcClientId = fulcioOidcClientId || "sigstore";
     fulcioOidcIssuer = fulcioOidcIssuer || "https://oauth2.sigstore.dev/auth";
-    timestampServers = timestampServers || "https://freetsa.org/tsr";
+    timestampServers = timestampServers || "https://timestamp.sigstore.dev/api/v1/timestamp";
   }
 
   if (attestations.length) {

--- a/index.js
+++ b/index.js
@@ -104,7 +104,7 @@ async function run() {
     fulcio = fulcio || "https://fulcio.sigstore.dev";
     fulcioOidcClientId = fulcioOidcClientId || "sigstore";
     fulcioOidcIssuer = fulcioOidcIssuer || "https://oauth2.sigstore.dev/auth";
-    timestampServers = timestampServers || "https://freetsa.org/tsr";
+    timestampServers = timestampServers || "https://timestamp.sigstore.dev/api/v1/timestamp";
   }
 
   if (attestations.length) {


### PR DESCRIPTION
Ensures a default timestamp server is used if the configuration does not specify one, but no longer always prepends freetsa.org, preventing errors with the upstream freetsa.org